### PR TITLE
Removed "_baseline "from trainer_baseline import Trainer"

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import argparse
 from models import get_model
 from data import make_data_loader
 import warnings
-from trainer_baseline import Trainer
+from trainer import Trainer
 import torch
 import torch.backends.cudnn as cudnn
 import random


### PR DESCRIPTION
Removed ```_baseline``` from ```from trainer_baseline import Trainer```. New replace is ```from trainer import Trainer```